### PR TITLE
Refactor: Remove unused Neon database dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
     "@jridgewell/trace-mapping": "^0.3.25",
-    "@neondatabase/serverless": "^0.10.4",
     "@radix-ui/react-accordion": "^1.2.4",
     "@radix-ui/react-alert-dialog": "^1.1.7",
     "@radix-ui/react-aspect-ratio": "^1.1.3",


### PR DESCRIPTION
The application was found to be already configured to use Supabase as its primary PostgreSQL database provider. Connections in `server/db.ts`, `server/db-alt.ts`, and `server/db-direct.ts` all point to Supabase. The Drizzle ORM configuration (`drizzle.config.ts`) also utilizes `DATABASE_URL` which, as per your confirmation and `.env.example`, is intended for the Supabase connection string.

This commit removes the `@neondatabase/serverless` package from `package.json` as it was an unused, lingering dependency from a potential previous database setup. No other code changes were necessary as the migration to Supabase was already complete.